### PR TITLE
Set relationship to CCMS to be from Apply web instead of system

### DIFF
--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -52,7 +52,7 @@ class Apply private constructor() {
 
     override fun defineRelationships() {
       // system relationships
-      system.uses(CCMS.system, "Gets provider details and reference data from and submits application through")
+      web.uses(CCMS.system, "Gets provider details and reference data from and submits application through")
 
       // container relationships
       web.uses(CCMS.providerDetailsAPI, "Gets provider details from", "REST")


### PR DESCRIPTION
## What does this pull request do?

When viewing the container diagram it would only show one relationship
with CCMS, omitting the second one.

To fix this, we set the system relationship to CCMS to be from the
container that owns that relationship, instead of the system as a
whole.

This way the relationship is correctly summarised on all diagrams, but
still shows all the detail on the CCMS side as well.

## What is the intent behind these changes?

To fix the missing details in the Apply <> CCMS relationships.
