### PR TITLE
Show CCMS container relationships on Apply

### DIFF
--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -5,6 +5,7 @@ import com.structurizr.model.Model
 import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ContainerView
 import com.structurizr.view.ViewSet
 
 class Apply private constructor() {
@@ -83,8 +84,15 @@ class Apply private constructor() {
 
       views.createContainerView(system, "apply-container", null).apply {
         addDefaultElements()
+        renderInternalCcmsContainers(this)
+        setExternalSoftwareSystemBoundariesVisible(true)
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
       }
+    }
+
+    private fun renderInternalCcmsContainers(view: ContainerView) {
+      view.remove(CCMS.system)
+      listOf(CCMS.soa, CCMS.providerDetailsAPI).forEach { view.add(it) }
     }
   }
 }

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -69,7 +69,6 @@ class Apply private constructor() {
       // user relationships
       applicant.uses(web, "Provides personal and financial information at")
       applicant.uses(TrueLayer.system, "Gives bank access authorisation to")
-      // applicant.uses(GOVUKNotify.system, "Gets an email from")
       provider.uses(web, "Fills legal aid application through")
       provider.uses(Portal.system, "Provides login credentials through")
       GOVUKNotify.system.delivers(applicant, "Sends email to")


### PR DESCRIPTION
## What does this pull request do?

This pull request removes the CCMS system from the Apply container diagram and replaces it with the containers that Apply interacts with.

It's a bit of hard coding but it's useful to do this for large legacy systems that do many different things, like CCMS.

It also removes an unused commented out line left in there from previous pull requests.

## What is the intent behind these changes?

To give a better overview of what Apply talks to. Previously we only saw a single relationship with CCMS, but it's useful to see the different containers within CCMS that Apply talks to.