### PR TITLE
Add diagrams for FALA

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -15,7 +15,11 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   Geckoboard,
   TrueLayer,
   GOVUKNotify,
-  Portal
+  Portal,
+  FALA,
+  PostcodesIO,
+  CLA,
+  LegalAidAgencyUsers
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.architecture
 
 import com.structurizr.model.Container
 import com.structurizr.model.Model
-import com.structurizr.model.Person
 import com.structurizr.model.SoftwareSystem
 import com.structurizr.view.AutomaticLayout
 import com.structurizr.view.ContainerView
@@ -12,8 +11,6 @@ class Apply private constructor() {
   companion object : LAASoftwareSystem {
     lateinit var system: SoftwareSystem
     lateinit var web: Container
-    lateinit var applicant: Person
-    lateinit var provider: Person
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -35,7 +32,7 @@ class Apply private constructor() {
         Tags.DATABASE.addTo(this)
         CloudPlatform.rds.add(this)
       }
-      web.uses(db, "connects to")
+      web.uses(db, "Connects to")
 
       val sidekiq = system.addContainer("Sidekiq", "Listens to queued events and processes them", "Sidekiq").apply {
         CloudPlatform.kubernetes.add(this)
@@ -44,11 +41,8 @@ class Apply private constructor() {
         Tags.DATABASE.addTo(this)
         CloudPlatform.elasticache.add(this)
       }
-      sidekiq.uses(queue, "processes queued jobs from")
-      web.uses(queue, "queues feedback jobs to")
-
-      applicant = model.addPerson("Legal aid applicant", "Defendant requiring civil legal aid")
-      provider = model.addPerson("Legal aid provider", "Civil legal aid provider")
+      sidekiq.uses(queue, "Processes queued jobs from")
+      web.uses(queue, "Queues feedback jobs to")
     }
 
     override fun defineRelationships() {
@@ -68,11 +62,11 @@ class Apply private constructor() {
       web.uses(GOVUKNotify.system, "Sends email using", "REST")
 
       // user relationships
-      applicant.uses(web, "Provides personal and financial information at")
-      applicant.uses(TrueLayer.system, "Gives bank access authorisation to")
-      provider.uses(web, "Fills legal aid application through")
-      provider.uses(Portal.system, "Provides login credentials through")
-      GOVUKNotify.system.delivers(applicant, "Sends email to")
+      LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")
+      LegalAidAgencyUsers.citizen.uses(TrueLayer.system, "Gives bank access authorisation to")
+      LegalAidAgencyUsers.provider.uses(web, "Fills legal aid application through")
+      LegalAidAgencyUsers.provider.uses(Portal.system, "Provides login credentials through")
+      GOVUKNotify.system.delivers(LegalAidAgencyUsers.citizen, "Sends email to")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/CLA.kt
+++ b/src/main/kotlin/model/CLA.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ViewSet
+
+class CLA private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+    lateinit var claPublic: Container
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Civil Legal Advice",
+        "Service for citizens to check if they are eligible for legal aid")
+
+      claPublic = system.addContainer(
+        "Civil Legal Advice Public UI",
+        "A public web service which allows citizens to check if they are eligible for legal aid",
+        "Flask"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/cla_public")
+      }
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers
+      claPublic.uses(FALA.laalaa, "Performs legal adviser searches through", "REST")
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+      views.createSystemContextView(system, "cla-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+
+      views.createContainerView(system, "cla-container", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/model/FALA.kt
+++ b/src/main/kotlin/model/FALA.kt
@@ -1,0 +1,91 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.Person
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ViewSet
+
+class FALA private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+    lateinit var web: Container
+    lateinit var laalaa: Container
+    lateinit var callCentreOperator: Person
+    lateinit var managementInformationTeam: Person
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Find a Legal Adviser",
+        "Search for a legal adviser or family mediator with a legal aid contract in England and Wales"
+      )
+
+      web = system.addContainer(
+        "Find a Legal Adviser UI",
+        "Interface to search for legal advisers in an area",
+        "Django"
+      ).apply {
+        Tags.WEB_BROWSER.addTo(this)
+        setUrl("https://github.com/ministryofjustice/fala")
+      }
+
+      laalaa = system.addContainer(
+        "Legal Aid Agency Legal Adviser API",
+        "A JSON API for looking up legal advisers",
+        "Flask"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/laa-legal-adviser-api")
+      }
+      web.uses(laalaa, "Performs legal adviser searches through", "REST")
+
+      val db = system.addContainer(
+        "Provider address database",
+        "Stores provider address details with latitude and longitude coordinates",
+        "PostgreSQL with PostGIS")
+      .apply {
+        Tags.DATABASE.addTo(this)
+        CloudPlatform.rds.add(this)
+      }
+      laalaa.uses(db, "connects to")
+
+      val celery = system.addContainer("Celery", "Listens to queued events and processes them", "Celery").apply {
+        CloudPlatform.kubernetes.add(this)
+      }
+      val queue = system.addContainer("Queue", "Key-value store used for scheduling jobs via Celery", "Redis").apply {
+        Tags.DATABASE.addTo(this)
+        CloudPlatform.elasticache.add(this)
+      }
+      celery.uses(queue, "Processes queued postcode lookup jobs from")
+      laalaa.uses(queue, "Queues postcode lookup jobs to")
+
+      callCentreOperator = model.addPerson(
+        "Call centre operator",
+        "Contact centre personnel who signposts members of the public in their legal help queries"
+      )
+      managementInformationTeam = model.addPerson("Management Information Team")
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers
+      laalaa.uses(PostcodesIO.system, "Looks up postcode latitude and longitude from", "REST")
+      LegalAidAgencyUsers.citizen.uses(web, "Looks for nearby legal advisers using")
+      LegalAidAgencyUsers.provider.uses(web, "Looks for nearby legal advisers for citizens using")
+      callCentreOperator.uses(web, "Looks for nearby legal advisers for citizens using")
+      managementInformationTeam.uses(web, "Logs in every month and updates legal provider details")
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+      views.createSystemContextView(system, "fala-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+
+      views.createContainerView(system, "fala-container", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.Person
+import com.structurizr.view.ViewSet
+
+class LegalAidAgencyUsers private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var citizen: Person
+    lateinit var provider: Person
+
+    override fun defineModelEntities(model: Model) {
+      citizen = model.addPerson("A member of the public in England and Wales")
+      provider = model.addPerson("Legal Aid Provider")
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}

--- a/src/main/kotlin/model/PostcodesIO.kt
+++ b/src/main/kotlin/model/PostcodesIO.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class PostcodesIO private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "postcodes.io",
+        "API for looking up information about UK postcodes"
+      ).apply {
+        OutsideLAA.addTo(this)
+      }
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

This creates diagrams for FALA (Find a legal adviser), including LAALAA (LAA Legal Adviser API) and a skeleton for
CLA as well.

The users that are shared with Apply have also been moved to a
separate class for reusability.

## What is the intent behind these changes?

To document the systems around the FALA service. CLA will be done separately.

## Previews

FALA containers:
![structurizr-55246-fala-container](https://user-images.githubusercontent.com/1471406/94812225-5b12f180-03ee-11eb-8fd1-919489b6a6f1.png)

FALA system context:
![structurizr-55246-fala-context](https://user-images.githubusercontent.com/1471406/94812246-6403c300-03ee-11eb-9508-a013fd9eb6a7.png)

LAA system landscape
![structurizr-55246-system-overview](https://user-images.githubusercontent.com/1471406/94812280-6e25c180-03ee-11eb-81b0-da1b0ca9a222.png)

