### PR TITLE
Add View Court Data application

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -20,7 +20,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   PostcodesIO,
   CLA,
   LegalAidAgencyUsers,
-  EligibilityCalculator
+  EligibilityCalculator,
+  VCD
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -8,10 +8,18 @@ class LegalAidAgencyUsers private constructor() {
   companion object : LAASoftwareSystem {
     lateinit var citizen: Person
     lateinit var provider: Person
+    lateinit var crimeApplicationCaseWorker: Person
+    lateinit var billingCaseWorker: Person
 
     override fun defineModelEntities(model: Model) {
       citizen = model.addPerson("A member of the public in England and Wales")
       provider = model.addPerson("Legal Aid Provider")
+
+      crimeApplicationCaseWorker = model.addPerson(
+        "Legal aid crime application case worker", 
+        "Manages applications for criminal legal aid"
+      )
+      billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills") 
     }
 
     override fun defineRelationships() {

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -35,7 +35,7 @@ class VCD private constructor() {
         Tags.DATABASE.addTo(this)
         CloudPlatform.rds.add(this)
       }
-      web.uses(db, "connects to")
+      web.uses(db, "Connects to")
 
       val sidekiq = system.addContainer("Sidekiq", "Listens to queued events and processes them", "Sidekiq").apply {
         CloudPlatform.kubernetes.add(this)
@@ -44,8 +44,8 @@ class VCD private constructor() {
         Tags.DATABASE.addTo(this)
         CloudPlatform.elasticache.add(this)
       }
-      sidekiq.uses(queue, "processes queued jobs from")
-      web.uses(queue, "queues feedback jobs to")
+      sidekiq.uses(queue, "Processes queued jobs from")
+      web.uses(queue, "Queues feedback jobs to")
 
       applicationCaseWorker = model.addPerson(
         "Legal aid application case worker", 

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -49,7 +49,7 @@ class VCD private constructor() {
 
       applicationCaseWorker = model.addPerson(
         "Legal aid application case worker", 
-        "Manage applications for criminal legal aid"
+        "Manages applications for criminal legal aid"
       )
       billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills")
     }

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -55,7 +55,7 @@ class VCD private constructor() {
     }
 
     override fun defineRelationships() {
-      // // user relationships
+      // user relationships
       applicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
       billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
     }

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -17,8 +17,9 @@ class VCD private constructor() {
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
-        "VCD (View Court Data)",
-        "The laa-court-data-ui system is a web service that Application and Billing case workers use to interact with the Courts"
+        "VCD (View Court Data)", 
+        "The laa-court-data-ui system is a web service that Application and Billing case workers use to interact " +
+          "with the Courts"
       )
 
       web = system.addContainer(
@@ -46,7 +47,10 @@ class VCD private constructor() {
       sidekiq.uses(queue, "processes queued jobs from")
       web.uses(queue, "queues feedback jobs to")
 
-      applicationCaseWorker = model.addPerson("Legal aid application case worker", "Manage applications for criminal legal aid")
+      applicationCaseWorker = model.addPerson(
+        "Legal aid application case worker", 
+        "Manage applications for criminal legal aid"
+      )
       billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills")
     }
 

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.Person
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ContainerView
+import com.structurizr.view.ViewSet
+
+class VCD private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+    lateinit var web: Container
+    lateinit var applicationCaseWorker: Person
+    lateinit var billingCaseWorker: Person
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "VCD (View Court Data)",
+        "The laa-court-data-ui system is a web service that Application and Billing case workers use to interact with the Courts"
+      )
+
+      web = system.addContainer(
+        "VCD UI",
+        "Interface for Application and Billing case workers access the Court's data",
+        "Ruby on Rails"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/laa-court-data-ui")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      val db = system.addContainer("VCD Database", "Stores user details for the application", "PostgreSQL").apply {
+        Tags.DATABASE.addTo(this)
+        CloudPlatform.rds.add(this)
+      }
+      web.uses(db, "connects to")
+
+      val sidekiq = system.addContainer("Sidekiq", "Listens to queued events and processes them", "Sidekiq").apply {
+        CloudPlatform.kubernetes.add(this)
+      }
+      val queue = system.addContainer("Queue", "Key-value store used for scheduling jobs via Sidekiq", "Redis").apply {
+        Tags.DATABASE.addTo(this)
+        CloudPlatform.elasticache.add(this)
+      }
+      sidekiq.uses(queue, "processes queued jobs from")
+      web.uses(queue, "queues feedback jobs to")
+
+      applicationCaseWorker = model.addPerson("Legal aid application case worker", "Manage applications for criminal legal aid")
+      billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills")
+    }
+
+    override fun defineRelationships() {
+      // // user relationships
+      applicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
+      billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+      views.createSystemContextView(system, "vcd-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+
+      views.createContainerView(system, "vcd-container", null).apply {
+        addDefaultElements()
+        setExternalSoftwareSystemBoundariesVisible(true)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -29,7 +29,9 @@ class VCD private constructor() {
         Tags.WEB_BROWSER.addTo(this)
       }
 
-      val db = system.addContainer("View Court Data Database", "Stores user details for the application", "PostgreSQL").apply {
+      val db = system.addContainer(
+        "View Court Data Database", "Stores user details for the application", "PostgreSQL"
+      ).apply {
         Tags.DATABASE.addTo(this)
         CloudPlatform.rds.add(this)
       }

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -17,13 +17,13 @@ class VCD private constructor() {
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
-        "VCD (View Court Data)", 
+        "View Court Data", 
         "The laa-court-data-ui system is a web service that Application and Billing case workers use to interact " +
           "with the Courts"
       )
 
       web = system.addContainer(
-        "VCD UI",
+        "View Court Data UI",
         "Interface for Application and Billing case workers access the Court's data",
         "Ruby on Rails"
       ).apply {
@@ -31,7 +31,7 @@ class VCD private constructor() {
         Tags.WEB_BROWSER.addTo(this)
       }
 
-      val db = system.addContainer("VCD Database", "Stores user details for the application", "PostgreSQL").apply {
+      val db = system.addContainer("View Court Data Database", "Stores user details for the application", "PostgreSQL").apply {
         Tags.DATABASE.addTo(this)
         CloudPlatform.rds.add(this)
       }

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -12,8 +12,6 @@ class VCD private constructor() {
   companion object : LAASoftwareSystem {
     lateinit var system: SoftwareSystem
     lateinit var web: Container
-    lateinit var applicationCaseWorker: Person
-    lateinit var billingCaseWorker: Person
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -46,18 +44,12 @@ class VCD private constructor() {
       }
       sidekiq.uses(queue, "Processes queued jobs from")
       web.uses(queue, "Queues feedback jobs to")
-
-      applicationCaseWorker = model.addPerson(
-        "Legal aid application case worker", 
-        "Manages applications for criminal legal aid"
-      )
-      billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills")
     }
 
     override fun defineRelationships() {
       // user relationships
-      applicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
-      billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
+      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
+      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
     }
 
     override fun defineViews(views: ViewSet) {


### PR DESCRIPTION
## What does this pull request do?

This creates diagrams for the VCD application without any dependencies. 

## What is the intent behind these changes?

To document only the View Court Data. Allowing me to get used to Kotlin and our diagramming solutions.

## Previews

VCD Container:

![structurizr-55246-vcd-container](https://user-images.githubusercontent.com/1273965/94815125-1a1cdc00-03f2-11eb-8705-3eb66a962c46.png)

VCD Context:

![structurizr-55246-vcd-context](https://user-images.githubusercontent.com/1273965/94815150-20ab5380-03f2-11eb-8543-0d2a93293445.png)


LAA system landscape:

![structurizr-55246-system-overview](https://user-images.githubusercontent.com/1273965/94815233-33258d00-03f2-11eb-900d-d0d19e8ddcde.png)

