### PR TITLE
Add a diagram for eligibility calculator

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -19,7 +19,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   FALA,
   PostcodesIO,
   CLA,
-  LegalAidAgencyUsers
+  LegalAidAgencyUsers,
+  EligibilityCalculator
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/EligibilityCalculator.kt
+++ b/src/main/kotlin/model/EligibilityCalculator.kt
@@ -1,0 +1,46 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ViewSet
+
+class EligibilityCalculator private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+    lateinit var web: Container
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Civil Legal Aid Eligibility Calculator",
+        "A service for assessing financial eligibility for civil legal aid")
+
+      web = system.addContainer(
+        "Eligibility Calculator UI",
+        "A web service for assesing legal aid eligibility",
+        "Classic ASP (VBScript), C#"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/cla_eligibility_calculator")
+      }
+      LegalAidAgencyUsers.provider.uses(web, "Assesses how much legal aid a citizen is eligible for using")
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+      views.createSystemContextView(system, "eligibility-calculator-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+
+      views.createContainerView(system, "eligibility-calculator-container", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Creates a diagram for eligibility calculator. This is a standalone system that doesn't talk to any other systems. It also stores no data so there's no database. Although it's accessible to the public, the only users are providers on behalf of citizens.

## What is the intent behind these changes?

To document the eligibility calculator system.

## System
![structurizr-55246-eligibility-calculator-context](https://user-images.githubusercontent.com/1471406/94928232-481a2300-04bb-11eb-87c5-b6594484200d.png)

## Containers
![structurizr-55246-eligibility-calculator-container](https://user-images.githubusercontent.com/1471406/94928221-43556f00-04bb-11eb-8855-dbb26d7688be.png)

