### PR TITLE
Add os places api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build
 
 # external dependencies
 ext/
+
+# Ignore MacOS system files
+.DS_Store

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -23,7 +23,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   EligibilityCalculator,
   VCD,
   CDA,
-  CommonPlatform
+  CommonPlatform,
+  OSPlacesAPI
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -60,6 +60,7 @@ class Apply private constructor() {
       web.uses(Geckoboard.system, "Sends metrics to", "REST")
       web.uses(TrueLayer.system, "Gets applicant bank information from", "REST")
       web.uses(GOVUKNotify.system, "Sends email using", "REST")
+      web.uses(OSPlacesAPI.system, "Gets address data from", "REST")
 
       // user relationships
       LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")

--- a/src/main/kotlin/model/OSPlacesAPI.kt
+++ b/src/main/kotlin/model/OSPlacesAPI.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class OSPlacesAPI private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem("OS Places", "Ordnance Survey postcode lookup API").apply {
+        OutsideLAA.addTo(this)
+      }
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

The OS Places API is an external service used by Apply to retrieve
address data based on a postcode lookup. This change adds a new model
for the service and adds a relationship to Apply.

## What is the intent behind these changes?

To accurately capture the relationship between Apply and its external dependencies.