### PR TITLE
Add BankHoliday API relationship

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,5 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" />
+  </settings>
+</component>

--- a/.idea/laa-architecture-as-code.iml
+++ b/.idea/laa-architecture-as-code.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="ruby-2.3.7-p456" project-jdk-type="RUBY_SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/laa-architecture-as-code.iml" filepath="$PROJECT_DIR$/.idea/laa-architecture-as-code.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectId" id="1idxRGDusynq4rhV317CWgAnaaS" />
+</project>

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -24,7 +24,9 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   VCD,
   CDA,
   CommonPlatform,
-  OSPlacesAPI
+  OSPlacesAPI,
+  BankHolidaysAPI
+
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -61,6 +61,7 @@ class Apply private constructor() {
       web.uses(TrueLayer.system, "Gets applicant bank information from", "REST")
       web.uses(GOVUKNotify.system, "Sends email using", "REST")
       web.uses(OSPlacesAPI.system, "Gets address data from", "REST")
+      web.uses(BankHolidaysAPI.system, "Gets UK bank holiday dates from", "REST")
 
       // user relationships
       LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")

--- a/src/main/kotlin/model/BankHolidaysAPI.kt
+++ b/src/main/kotlin/model/BankHolidaysAPI.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class BankHolidaysAPI private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem("BankHolidaysAPI", "GOVUK Bank Holiday API").apply {
+        OutsideLAA.addTo(this)
+      }
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Add a new model - BankHolidayAPI
Add a new relationship for the Apply service



## What is the intent behind these changes?

This service is used to identify bank holidays dates, which is used by Apply to calculate the number of working days in a particular period. It needs to be included to cover all of the relationships of Apply
