### PR TITLE
add bank holiday relationship

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -26,7 +26,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   CDA,
   CommonPlatform,
   OSPlacesAPI,
-  MAAT
+  MAAT,
+  BankHolidaysAPI
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -61,6 +61,7 @@ class Apply private constructor() {
       web.uses(TrueLayer.system, "Gets applicant bank information from", "REST")
       web.uses(GOVUKNotify.system, "Sends email using", "REST")
       web.uses(OSPlacesAPI.system, "Gets address data from", "REST")
+      web.uses(BankHolidaysAPI.system, "Gets UK bank holiday dates from", "REST")
 
       // user relationships
       LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")

--- a/src/main/kotlin/model/BankHolidaysAPI.kt
+++ b/src/main/kotlin/model/BankHolidaysAPI.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class BankHolidaysAPI private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem("BankHolidaysAPI", "GOVUK Bank Holiday API").apply {
+        OutsideLAA.addTo(this)
+      }
+    }
+
+    override fun defineRelationships() {
+      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineViews(views: ViewSet) {
+      // declare views here
+    }
+  }
+}


### PR DESCRIPTION

##What does this pull request do?
Add a new model - BankHolidayAPI
Add a new relationship for the Apply service

##What is the intent behind these changes?
This service is used to identify bank holidays dates, which is used by Apply to calculate the number of working days in a particular period. It needs to be included to cover all of the relationships of Apply
