### PR TITLE
Add Kotlin linting instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,13 @@ STRUCTURIZR_WORKSPACE_ID=12345 \
 
 You can view these secrets on the [dashboard](https://structurizr.com/dashboard), after clicking *Show more...* next to
 the desired workspace.
+
+### Linting Kotlin
+
+It's possible and recommended to lint your Kotlin code with `ktlint`.
+
+```sh
+ktlint src/main/kotlin/model/Apply.kt
+```
+
+Add the `-F` argument to attempt to automatically fix any linting errors.


### PR DESCRIPTION
## What does this pull request do?

Adds instructions on how to run the Kotlin linter.

## What is the intent behind these changes?

Most people aren't familiar with Kotlin, never mind the tooling around it such as the linter. As a result it felt useful to add this information to the README.
