### PR TITLE
Remove border around CCMS from Apply diagram

### DIFF
--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -80,7 +80,6 @@ class Apply private constructor() {
       views.createContainerView(system, "apply-container", null).apply {
         addDefaultElements()
         renderInternalCcmsContainers(this)
-        setExternalSoftwareSystemBoundariesVisible(true)
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
       }
     }


### PR DESCRIPTION
## What does this pull request do?

Removes the border around the CCMS components on the Apply container diagram.

## What is the intent behind these changes?

The border around CCMS tends to bug out a lot of the time unless the two CCMS
components are next to each other. It's nice to have but not
necessary, so this commit removes it.

