### PR TITLE
Refactor relationship definition in models

### DIFF
--- a/src/main/kotlin/LAASoftwareSystem.kt
+++ b/src/main/kotlin/LAASoftwareSystem.kt
@@ -5,6 +5,10 @@ import com.structurizr.view.ViewSet
 
 interface LAASoftwareSystem {
   fun defineModelEntities(model: Model)
+  fun defineInternalContainerRelationships()
+  // fun defineContainerRelationships()
+  // fun defineExternalContainerRelationships()
+  // fun defineUserRelationships()
   fun defineRelationships()
   fun defineViews(views: ViewSet)
 }

--- a/src/main/kotlin/LAASoftwareSystem.kt
+++ b/src/main/kotlin/LAASoftwareSystem.kt
@@ -6,9 +6,8 @@ import com.structurizr.view.ViewSet
 interface LAASoftwareSystem {
   fun defineModelEntities(model: Model)
   fun defineInternalContainerRelationships()
-  // fun defineContainerRelationships()
-  // fun defineExternalContainerRelationships()
-  // fun defineUserRelationships()
+  fun defineExternalRelationships()
   fun defineRelationships()
+  // fun defineUserRelationships()
   fun defineViews(views: ViewSet)
 }

--- a/src/main/kotlin/LAASoftwareSystem.kt
+++ b/src/main/kotlin/LAASoftwareSystem.kt
@@ -8,6 +8,6 @@ interface LAASoftwareSystem {
   fun defineInternalContainerRelationships()
   fun defineExternalRelationships()
   fun defineRelationships()
-  // fun defineUserRelationships()
+  fun defineUserRelationships()
   fun defineViews(views: ViewSet)
 }

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -49,7 +49,12 @@ private fun changeUndefinedLocationsToInternal(model: Model) {
 }
 
 private fun defineRelationships() {
-  MODEL_ITEMS.forEach { it.defineRelationships() }
+  MODEL_ITEMS.forEach {
+    it.defineInternalContainerRelationships()
+    it.defineExternalRelationships()
+    it.defineRelationships()
+    it.defineUserRelationships()
+    }
 }
 
 private fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -59,13 +59,6 @@ class Apply private constructor() {
       web.uses(CFE.api, "Checks applicant financial eligibility through", "REST")
       web.uses(BenefitChecker.api, "Checks if applicant receives passported benefit through", "SOAP")
       web.uses(Portal.system, "Authenticates users through", "SAML")
-
-      // user relationships
-      LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")
-      LegalAidAgencyUsers.citizen.uses(TrueLayer.system, "Gives bank access authorisation to")
-      LegalAidAgencyUsers.provider.uses(web, "Fills legal aid application through")
-      LegalAidAgencyUsers.provider.uses(Portal.system, "Provides login credentials through")
-      GOVUKNotify.system.delivers(LegalAidAgencyUsers.citizen, "Sends email to")
     }
 
     override fun defineExternalRelationships() {
@@ -74,6 +67,14 @@ class Apply private constructor() {
       web.uses(GOVUKNotify.system, "Sends email using", "REST")
       web.uses(OSPlacesAPI.system, "Gets address data from", "REST")
       web.uses(BankHolidaysAPI.system, "Gets UK bank holiday dates from", "REST")
+    }
+
+    override fun defineUserRelationships() {
+      LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")
+      LegalAidAgencyUsers.citizen.uses(TrueLayer.system, "Gives bank access authorisation to")
+      LegalAidAgencyUsers.provider.uses(web, "Fills legal aid application through")
+      LegalAidAgencyUsers.provider.uses(Portal.system, "Provides login credentials through")
+      GOVUKNotify.system.delivers(LegalAidAgencyUsers.citizen, "Sends email to")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -53,22 +53,12 @@ class Apply private constructor() {
     }
 
     override fun defineRelationships() {
-      // system relationships
       web.uses(CCMS.system, "Gets provider details and reference data from and submits application through")
-
-      // container relationships
       web.uses(CCMS.providerDetailsAPI, "Gets provider details from", "REST")
       web.uses(CCMS.soa, "Gets reference data and submits legal aid application through", "SOAP")
       web.uses(CFE.api, "Checks applicant financial eligibility through", "REST")
       web.uses(BenefitChecker.api, "Checks if applicant receives passported benefit through", "SOAP")
       web.uses(Portal.system, "Authenticates users through", "SAML")
-
-      // external container relationships
-      web.uses(Geckoboard.system, "Sends metrics to", "REST")
-      web.uses(TrueLayer.system, "Gets applicant bank information from", "REST")
-      web.uses(GOVUKNotify.system, "Sends email using", "REST")
-      web.uses(OSPlacesAPI.system, "Gets address data from", "REST")
-      web.uses(BankHolidaysAPI.system, "Gets UK bank holiday dates from", "REST")
 
       // user relationships
       LegalAidAgencyUsers.citizen.uses(web, "Applies for legal aid using")
@@ -78,8 +68,15 @@ class Apply private constructor() {
       GOVUKNotify.system.delivers(LegalAidAgencyUsers.citizen, "Sends email to")
     }
 
+    override fun defineExternalRelationships() {
+      web.uses(Geckoboard.system, "Sends metrics to", "REST")
+      web.uses(TrueLayer.system, "Gets applicant bank information from", "REST")
+      web.uses(GOVUKNotify.system, "Sends email using", "REST")
+      web.uses(OSPlacesAPI.system, "Gets address data from", "REST")
+      web.uses(BankHolidaysAPI.system, "Gets UK bank holiday dates from", "REST")
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "apply-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/BankHolidaysAPI.kt
+++ b/src/main/kotlin/model/BankHolidaysAPI.kt
@@ -14,12 +14,19 @@ class BankHolidaysAPI private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
+    }
+
+    override fun defineUserRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/BenefitChecker.kt
+++ b/src/main/kotlin/model/BenefitChecker.kt
@@ -23,6 +23,9 @@ class BenefitChecker private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers
     }

--- a/src/main/kotlin/model/BenefitChecker.kt
+++ b/src/main/kotlin/model/BenefitChecker.kt
@@ -27,11 +27,12 @@ class BenefitChecker private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "benefit-checker-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/BenefitChecker.kt
+++ b/src/main/kotlin/model/BenefitChecker.kt
@@ -32,6 +32,9 @@ class BenefitChecker private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "benefit-checker-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/CCMS.kt
+++ b/src/main/kotlin/model/CCMS.kt
@@ -46,13 +46,14 @@ class CCMS private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
-      soa.uses(Northgate.system, "manages documents in")
       soa.uses(BenefitChecker.system, "validates Universal Credit claimants via", "SOAP")
     }
 
+    override fun defineExternalRelationships() {
+      soa.uses(Northgate.system, "manages documents in")
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "ccms-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/CCMS.kt
+++ b/src/main/kotlin/model/CCMS.kt
@@ -11,6 +11,7 @@ class CCMS private constructor() {
     lateinit var system: SoftwareSystem
     lateinit var providerDetailsAPI: Container
     lateinit var soa: Container
+    lateinit var ebsDb: Container
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
@@ -30,14 +31,16 @@ class CCMS private constructor() {
         setUrl("https://github.com/ministryofjustice/laa-ccms-app-soa")
       }
 
-      val ebsDb = system.addContainer(
+      ebsDb = system.addContainer(
         "CCMS E-Business Suite Database",
         "Customised E-Business Suite DB",
         "Oracle"
       ).apply {
         Tags.DATABASE.addTo(this)
       }
+    }
 
+    override fun defineInternalContainerRelationships() {
       soa.uses(ebsDb, "connects to")
       providerDetailsAPI.uses(ebsDb, "connects to")
     }

--- a/src/main/kotlin/model/CCMS.kt
+++ b/src/main/kotlin/model/CCMS.kt
@@ -53,6 +53,9 @@ class CCMS private constructor() {
       soa.uses(Northgate.system, "manages documents in")
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "ccms-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/CDA.kt
+++ b/src/main/kotlin/model/CDA.kt
@@ -67,20 +67,21 @@ class CDA private constructor() {
 
     override fun defineRelationships() {
       api.uses(
-        CommonPlatform.system,
-        "Uses APIs to search and retreive case information and mark cases that LAA want to receive notifications for",
-        "REST (w/ mTLS)"
-      )
-
-      api.uses(
         MAAT.api,
         "Uses MAAT API to validate MAAT IDs before sending requests to Common Platform",
         "REST"
       )
     }
 
+    override fun defineExternalRelationships() {
+      api.uses(
+        CommonPlatform.system,
+        "Uses APIs to search and retreive case information and mark cases that LAA want to receive notifications for",
+        "REST (w/ mTLS)"
+      )
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "cda-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/CDA.kt
+++ b/src/main/kotlin/model/CDA.kt
@@ -81,6 +81,9 @@ class CDA private constructor() {
       )
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "cda-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/CFE.kt
+++ b/src/main/kotlin/model/CFE.kt
@@ -29,11 +29,12 @@ class CFE private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "cfe-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/CFE.kt
+++ b/src/main/kotlin/model/CFE.kt
@@ -34,6 +34,9 @@ class CFE private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "cfe-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/CFE.kt
+++ b/src/main/kotlin/model/CFE.kt
@@ -25,6 +25,9 @@ class CFE private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers
     }

--- a/src/main/kotlin/model/CLA.kt
+++ b/src/main/kotlin/model/CLA.kt
@@ -29,12 +29,13 @@ class CLA private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
       claPublic.uses(FALA.laalaa, "Performs legal adviser searches through", "REST")
     }
 
+    override fun defineExternalRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "cla-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/CLA.kt
+++ b/src/main/kotlin/model/CLA.kt
@@ -35,6 +35,9 @@ class CLA private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "cla-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/CLA.kt
+++ b/src/main/kotlin/model/CLA.kt
@@ -25,6 +25,9 @@ class CLA private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers
       claPublic.uses(FALA.laalaa, "Performs legal adviser searches through", "REST")

--- a/src/main/kotlin/model/CommonPlatform.kt
+++ b/src/main/kotlin/model/CommonPlatform.kt
@@ -21,12 +21,13 @@ class CommonPlatform private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
       system.uses(CDA.api, "Provides notifications when Hearings have resulted", "REST (w/ mTLS)")
     }
 
+    override fun defineExternalRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/CommonPlatform.kt
+++ b/src/main/kotlin/model/CommonPlatform.kt
@@ -27,6 +27,9 @@ class CommonPlatform private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/CommonPlatform.kt
+++ b/src/main/kotlin/model/CommonPlatform.kt
@@ -17,6 +17,9 @@ class CommonPlatform private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
       system.uses(CDA.api, "Provides notifications when Hearings have resulted", "REST (w/ mTLS)")

--- a/src/main/kotlin/model/EligibilityCalculator.kt
+++ b/src/main/kotlin/model/EligibilityCalculator.kt
@@ -23,7 +23,6 @@ class EligibilityCalculator private constructor() {
       ).apply {
         setUrl("https://github.com/ministryofjustice/cla_eligibility_calculator")
       }
-      LegalAidAgencyUsers.provider.uses(web, "Assesses how much legal aid a citizen is eligible for using")
     }
 
     override fun defineInternalContainerRelationships() {
@@ -33,6 +32,10 @@ class EligibilityCalculator private constructor() {
     }
 
     override fun defineExternalRelationships() {
+    }
+
+    override fun defineUserRelationships() {
+      LegalAidAgencyUsers.provider.uses(web, "Assesses how much legal aid a citizen is eligible for using")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/EligibilityCalculator.kt
+++ b/src/main/kotlin/model/EligibilityCalculator.kt
@@ -26,6 +26,9 @@ class EligibilityCalculator private constructor() {
       LegalAidAgencyUsers.provider.uses(web, "Assesses how much legal aid a citizen is eligible for using")
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers
     }

--- a/src/main/kotlin/model/EligibilityCalculator.kt
+++ b/src/main/kotlin/model/EligibilityCalculator.kt
@@ -30,11 +30,12 @@ class EligibilityCalculator private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "eligibility-calculator-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/FALA.kt
+++ b/src/main/kotlin/model/FALA.kt
@@ -74,16 +74,18 @@ class FALA private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
-      laalaa.uses(PostcodesIO.system, "Looks up postcode latitude and longitude from", "REST")
+      // User relationships
       LegalAidAgencyUsers.citizen.uses(web, "Looks for nearby legal advisers using")
       LegalAidAgencyUsers.provider.uses(web, "Looks for nearby legal advisers for citizens using")
       callCentreOperator.uses(web, "Looks for nearby legal advisers for citizens using")
       managementInformationTeam.uses(web, "Logs in every month and updates legal provider details")
     }
 
+    override fun defineExternalRelationships() {
+      laalaa.uses(PostcodesIO.system, "Looks up postcode latitude and longitude from", "REST")
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "fala-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/FALA.kt
+++ b/src/main/kotlin/model/FALA.kt
@@ -74,15 +74,17 @@ class FALA private constructor() {
     }
 
     override fun defineRelationships() {
-      // User relationships
-      LegalAidAgencyUsers.citizen.uses(web, "Looks for nearby legal advisers using")
-      LegalAidAgencyUsers.provider.uses(web, "Looks for nearby legal advisers for citizens using")
-      callCentreOperator.uses(web, "Looks for nearby legal advisers for citizens using")
-      managementInformationTeam.uses(web, "Logs in every month and updates legal provider details")
     }
 
     override fun defineExternalRelationships() {
       laalaa.uses(PostcodesIO.system, "Looks up postcode latitude and longitude from", "REST")
+    }
+
+    override fun defineUserRelationships() {
+      LegalAidAgencyUsers.citizen.uses(web, "Looks for nearby legal advisers using")
+      LegalAidAgencyUsers.provider.uses(web, "Looks for nearby legal advisers for citizens using")
+      callCentreOperator.uses(web, "Looks for nearby legal advisers for citizens using")
+      managementInformationTeam.uses(web, "Logs in every month and updates legal provider details")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/GOVUKNotify.kt
+++ b/src/main/kotlin/model/GOVUKNotify.kt
@@ -17,6 +17,9 @@ class GOVUKNotify private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
     }

--- a/src/main/kotlin/model/GOVUKNotify.kt
+++ b/src/main/kotlin/model/GOVUKNotify.kt
@@ -26,6 +26,9 @@ class GOVUKNotify private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/GOVUKNotify.kt
+++ b/src/main/kotlin/model/GOVUKNotify.kt
@@ -21,11 +21,12 @@ class GOVUKNotify private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/Geckoboard.kt
+++ b/src/main/kotlin/model/Geckoboard.kt
@@ -23,6 +23,9 @@ class Geckoboard private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/Geckoboard.kt
+++ b/src/main/kotlin/model/Geckoboard.kt
@@ -14,6 +14,9 @@ class Geckoboard private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
     }

--- a/src/main/kotlin/model/Geckoboard.kt
+++ b/src/main/kotlin/model/Geckoboard.kt
@@ -18,11 +18,12 @@ class Geckoboard private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -31,6 +31,9 @@ class LegalAidAgencyUsers private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -16,10 +16,13 @@ class LegalAidAgencyUsers private constructor() {
       provider = model.addPerson("Legal Aid Provider")
 
       crimeApplicationCaseWorker = model.addPerson(
-        "Legal aid crime application case worker", 
+        "Legal aid crime application case worker",
         "Manages applications for criminal legal aid"
       )
-      billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills") 
+      billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills")
+    }
+
+    override fun defineInternalContainerRelationships() {
     }
 
     override fun defineRelationships() {

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -28,6 +28,9 @@ class LegalAidAgencyUsers private constructor() {
     override fun defineRelationships() {
     }
 
+    override fun defineExternalRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/MAAT.kt
+++ b/src/main/kotlin/model/MAAT.kt
@@ -35,12 +35,10 @@ class MAAT private constructor() {
         setUrl("https://github.com/ministryofjustice/laa-maat-database")
         AWSLegacy.rds.add(this)
       }
+    }
 
-      api.uses(
-        db,
-        "Accesses and stores Court information",
-        "Oracle PL/SQL"
-      )
+    override fun defineInternalContainerRelationships() {
+      api.uses(db, "Accesses and stores Court information", "Oracle PL/SQL")
     }
 
     override fun defineRelationships() {

--- a/src/main/kotlin/model/MAAT.kt
+++ b/src/main/kotlin/model/MAAT.kt
@@ -42,16 +42,15 @@ class MAAT private constructor() {
     }
 
     override fun defineRelationships() {
-      // system relationships
       api.uses(CDA.system, "Sends status updates to and process events from")
-
-      // container relationships
       api.uses(CDA.api, "Posts offence level status events", "REST")
       api.uses(CDA.sqsQueue, "Processes notifications from the queue", "SQS")
     }
 
+    override fun defineExternalRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "maat-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/MAAT.kt
+++ b/src/main/kotlin/model/MAAT.kt
@@ -50,6 +50,9 @@ class MAAT private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "maat-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/Northgate.kt
+++ b/src/main/kotlin/model/Northgate.kt
@@ -26,6 +26,9 @@ class Northgate private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/Northgate.kt
+++ b/src/main/kotlin/model/Northgate.kt
@@ -21,11 +21,12 @@ class Northgate private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/Northgate.kt
+++ b/src/main/kotlin/model/Northgate.kt
@@ -17,6 +17,9 @@ class Northgate private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
     }

--- a/src/main/kotlin/model/OSPlacesAPI.kt
+++ b/src/main/kotlin/model/OSPlacesAPI.kt
@@ -23,6 +23,9 @@ class OSPlacesAPI private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/OSPlacesAPI.kt
+++ b/src/main/kotlin/model/OSPlacesAPI.kt
@@ -18,11 +18,12 @@ class OSPlacesAPI private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/OSPlacesAPI.kt
+++ b/src/main/kotlin/model/OSPlacesAPI.kt
@@ -14,6 +14,9 @@ class OSPlacesAPI private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
     }

--- a/src/main/kotlin/model/Portal.kt
+++ b/src/main/kotlin/model/Portal.kt
@@ -19,11 +19,12 @@ class Portal private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "portal-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/Portal.kt
+++ b/src/main/kotlin/model/Portal.kt
@@ -15,6 +15,9 @@ class Portal private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers
     }

--- a/src/main/kotlin/model/Portal.kt
+++ b/src/main/kotlin/model/Portal.kt
@@ -24,6 +24,9 @@ class Portal private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "portal-context", null).apply {
         addDefaultElements()

--- a/src/main/kotlin/model/PostcodesIO.kt
+++ b/src/main/kotlin/model/PostcodesIO.kt
@@ -17,6 +17,9 @@ class PostcodesIO private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
     }

--- a/src/main/kotlin/model/PostcodesIO.kt
+++ b/src/main/kotlin/model/PostcodesIO.kt
@@ -21,11 +21,12 @@ class PostcodesIO private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/PostcodesIO.kt
+++ b/src/main/kotlin/model/PostcodesIO.kt
@@ -26,6 +26,9 @@ class PostcodesIO private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
     }
   }

--- a/src/main/kotlin/model/TrueLayer.kt
+++ b/src/main/kotlin/model/TrueLayer.kt
@@ -23,8 +23,10 @@ class TrueLayer private constructor() {
     override fun defineExternalRelationships() {
     }
 
+    override fun defineUserRelationships() {
+    }
+
     override fun defineViews(views: ViewSet) {
-      // declare views here
     }
   }
 }

--- a/src/main/kotlin/model/TrueLayer.kt
+++ b/src/main/kotlin/model/TrueLayer.kt
@@ -18,7 +18,9 @@ class TrueLayer private constructor() {
     }
 
     override fun defineRelationships() {
-      // declare relationships to other systems and other system containers here
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/TrueLayer.kt
+++ b/src/main/kotlin/model/TrueLayer.kt
@@ -14,6 +14,9 @@ class TrueLayer private constructor() {
       }
     }
 
+    override fun defineInternalContainerRelationships() {
+    }
+
     override fun defineRelationships() {
       // declare relationships to other systems and other system containers here
     }

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -55,20 +55,21 @@ class VCD private constructor() {
     }
 
     override fun defineRelationships() {
-      // user relationships
-      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
-      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
-
-      // declare relationships to other systems and other system containers
       web.uses(
         CDA.api,
         "Provides interface to HMCTS Common Platform to access Court case and hearing information",
         "REST"
       )
+
+      // user relationships
+      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
+      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
+    }
+
+    override fun defineExternalRelationships() {
     }
 
     override fun defineViews(views: ViewSet) {
-      // declare views here
       views.createSystemContextView(system, "vcd-context", null).apply {
         addDefaultElements()
         enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -60,13 +60,14 @@ class VCD private constructor() {
         "Provides interface to HMCTS Common Platform to access Court case and hearing information",
         "REST"
       )
-
-      // user relationships
-      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
-      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
     }
 
     override fun defineExternalRelationships() {
+    }
+
+    override fun defineUserRelationships() {
+      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
+      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
     }
 
     override fun defineViews(views: ViewSet) {


### PR DESCRIPTION
## What does this pull request do?

Refactors the models to use several different methods to define relationships:

1) `defineInternalContainerRelationships`: For defining relationships between the model's own containers
2) `defineExternalRelationships`: For defining relationships between the model's containers and systems/containers that are not owned by the LAA
3) `defineRelationships`: Any other relationships go here, mainly relationships with other LAA systems
4) `defineUserRelationships`: Any user relationships for the model go here

There should be no changes to any diagrams.

Addresses https://github.com/ministryofjustice/laa-architecture-as-code/issues/30

## What is the intent behind these changes?

To better organise the definition of relationships in our code to make the code easier to read and modify. Some bigger models were getting messy.

The downside is that there's a bit more boilerplate.
