### PR TITLE
Make explicit which actors are Internal/External

### DIFF
--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.architecture
 
+import com.structurizr.model.Location
 import com.structurizr.model.Model
 import com.structurizr.model.Person
 import com.structurizr.view.ViewSet
@@ -12,14 +13,19 @@ class LegalAidAgencyUsers private constructor() {
     lateinit var billingCaseWorker: Person
 
     override fun defineModelEntities(model: Model) {
-      citizen = model.addPerson("A member of the public in England and Wales")
-      provider = model.addPerson("Legal Aid Provider")
+      citizen = model.addPerson(Location.External, "A member of the public in England and Wales", null)
+      provider = model.addPerson(Location.External, "Legal Aid Provider", null)
 
       crimeApplicationCaseWorker = model.addPerson(
+        Location.Internal,
         "Legal aid crime application case worker",
         "Manages applications for criminal legal aid"
       )
-      billingCaseWorker = model.addPerson("Legal aid billing case workers", "Verifies legal aid provider's bills")
+      billingCaseWorker = model.addPerson(
+        Location.Internal,
+        "Legal aid billing case workers",
+        "Verifies legal aid provider's bills"
+      )
     }
 
     override fun defineInternalContainerRelationships() {


### PR DESCRIPTION
## What does this pull request do?

Example diagram showing an internal & external person:

![image](https://user-images.githubusercontent.com/976274/96898457-a36e7e00-1487-11eb-961d-aa07447cd0fb.png)


## What is the intent behind these changes?

Context diagrams then visualise whether an actor is inside the LAA bounded box or not.
