### PR TITLE
Remove "Digital" from "Legal Aid Agency Digital"

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -66,7 +66,7 @@ private fun defineViews(views: ViewSet) {
 }
 
 fun defineWorkspace(): Workspace {
-  val enterprise = Enterprise("Legal Aid Agency Digital")
+  val enterprise = Enterprise("Legal Aid Agency")
   val workspace = Workspace(enterprise.name, "Systems related to the delivery of legal aid")
   workspace.id = 55246
   workspace.model.enterprise = enterprise


### PR DESCRIPTION
## What does this pull request do?

Remove "Digital" from "Legal Aid Agency Digital".

See the title top left in this diagram:

![image](https://user-images.githubusercontent.com/976274/96900507-15e05d80-148a-11eb-9569-cb38a3883aab.png)


## What is the intent behind these changes?

I believe we should include all LAA services, and if we need to differentiate "Digital" services, we do this at a lower level.
Perhaps as a Tag.
