### PR TITLE
Upgrade structurizr-core and structurizr-client to 1.6.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,6 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("com.structurizr:structurizr-client:1.4.5")
-    implementation("com.structurizr:structurizr-core:1.4.5")
+    implementation("com.structurizr:structurizr-client:1.6.2")
+    implementation("com.structurizr:structurizr-core:1.6.2")
 }


### PR DESCRIPTION
## What does this pull request do?

Upgrade structurizr-core and structurizr-client to 1.6.2.

## What is the intent behind these changes?

Keep up to date with the latest version of structurizr.
