### PR TITLE
Change Apply layout to be more vertical

### DIFF
--- a/src/main/kotlin/model/Apply.kt
+++ b/src/main/kotlin/model/Apply.kt
@@ -92,7 +92,7 @@ class Apply private constructor() {
       views.createContainerView(system, "apply-container", null).apply {
         addDefaultElements()
         renderInternalCcmsContainers(this)
-        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.LeftRight, 400, 100)
       }
     }
 


### PR DESCRIPTION
## What does this pull request do?

This commit changes the layout of Apply to be more vertical and to reduce spacing slightly. This make it a bit better for embedding in external documents.

It'll look something like this:

![image](https://user-images.githubusercontent.com/1471406/99693678-8aa3b900-2a83-11eb-9adf-2c54ddad51b7.png)

## What is the intent behind these changes?

The current layout is really wide, which makes it awkward to embed in GitHub READMEs and other documents. This improves the situation by making the layout more vertical.
