### PR TITLE
Populate CLA diagram

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -32,7 +32,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   CCR,
   CCLF,
   CIS,
-  CWA
+  CWA,
+  SendGrid
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -33,7 +33,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   CCLF,
   CIS,
   CWA,
-  SendGrid
+  SendGrid,
+  TAD
 )
 
 private fun defineModelItems(model: Model) {

--- a/src/main/kotlin/model/CLA.kt
+++ b/src/main/kotlin/model/CLA.kt
@@ -10,11 +10,19 @@ class CLA private constructor() {
   companion object : LAASoftwareSystem {
     lateinit var system: SoftwareSystem
     lateinit var claPublic: Container
+    lateinit var claBackend: Container
+    lateinit var claFrontend: Container
+    lateinit var claManagementInformation: Container
+    lateinit var db: Container
+    lateinit var replicaDb: Container
+    lateinit var queue: Container
+    lateinit var celery: Container
 
     override fun defineModelEntities(model: Model) {
       system = model.addSoftwareSystem(
         "Civil Legal Advice",
-        "Service for citizens to check if they are eligible for legal aid")
+        "Service for citizens to check if they are eligible for legal aid"
+      )
 
       claPublic = system.addContainer(
         "Civil Legal Advice Public UI",
@@ -22,26 +30,112 @@ class CLA private constructor() {
         "Flask"
       ).apply {
         setUrl("https://github.com/ministryofjustice/cla_public")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      claBackend = system.addContainer(
+        "Civil Legal Advice Backend API",
+        "API for managing civil legal aid cases",
+        "Django"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/cla_backend")
+      }
+
+      claFrontend = system.addContainer(
+        "Civil Legal Advice Frontend",
+        "A frontend web application that allows managing civil legal aid applications and callbacks",
+        "Django"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/cla_frontend")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      claManagementInformation = system.addContainer(
+        "Civil Legal Advice Management Information",
+        "Application to process the information from CLA Backend into TAD",
+        "Oracle Application Express (APEX)"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/laa-apex")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      db = system.addContainer(
+        "Civil Legal Aid Database",
+        "Stores civil legal aid cases, callbacks, logins, and specialist provider submissions",
+        "PostgreSQL"
+      ).apply {
+        Tags.DATABASE.addTo(this)
+        CloudPlatform.rds.add(this)
+      }
+
+      replicaDb = system.addContainer(
+        "Civil Legal Aid Replica Database",
+        "Replica database used for generating reports",
+        "PostgreSQL"
+      ).apply {
+        Tags.DATABASE.addTo(this)
+        CloudPlatform.rds.add(this)
+      }
+
+      celery = system.addContainer("Celery", "Listens to queued events and processes them", "Celery").apply {
+        CloudPlatform.kubernetes.add(this)
+      }
+
+      queue = system.addContainer("Queue", "Queue used for scheduling jobs via Celery", "AWS SQS").apply {
+        CloudPlatform.sqs.add(this)
       }
     }
 
     override fun defineInternalContainerRelationships() {
+      claPublic.uses(claBackend, "Stores cases and callback details using", "REST")
+      claBackend.uses(db, "Connects to")
+      claBackend.uses(replicaDb, "Generates reports from")
+      db.uses(replicaDb, "Replicates to")
+      claBackend.uses(queue, "Queues jobs to")
+      celery.uses(queue, "Processes queued jobs from")
+      celery.uses(claFrontend, "Sends notifications to")
+      claFrontend.uses(claBackend, "Manages cases, callbacks, logins, and submissions using", "REST")
     }
 
     override fun defineRelationships() {
-      claPublic.uses(FALA.laalaa, "Performs legal adviser searches through", "REST")
+      claPublic.uses(FALA.laalaa, "Finds out which providers are near the user using", "REST")
+      claManagementInformation.uses(TAD.db, "Stores data from OBIEE extract ZIP file upload")
     }
 
     override fun defineExternalRelationships() {
+      claPublic.uses(OSPlacesAPI.system, "Gets address data from", "REST")
+      claPublic.uses(SendGrid.system, "Sends confirmation and notification emails using", "REST")
     }
 
     override fun defineUserRelationships() {
+      SendGrid.system.delivers(LegalAidAgencyUsers.citizen, "Sends email to")
+      LegalAidAgencyUsers.citizen.uses(claPublic, "Checks if they can get legal aid using")
+      LegalAidAgencyUsers.provider.uses(claFrontend, "Logs in and uploads work report CSV")
+
+      LegalAidAgencyUsers.directServicesTeam.uses(
+        system,
+        "Downloads OBIEE extract ZIP files from CLA Backend and uploads to CLA MI, and views cases in CLA frontend " +
+          "to manage contracts"
+      )
+
+      LegalAidAgencyUsers.directServicesTeam.uses(claBackend, "Downloads OBIEE extract ZIP file")
+      LegalAidAgencyUsers.directServicesTeam.uses(claManagementInformation, "Uploads OBIEE extract ZIP file")
+      LegalAidAgencyUsers.directServicesTeam.uses(
+        claFrontend,
+        "Veiws cases to manage the specialist provider and operator service " +
+          "conracts"
+      )
+
+      LegalAidAgencyUsers.contactCentreOperator.uses(
+        claFrontend,
+        "Checks eligibility and data of incoming legal aid requests"
+      )
     }
 
     override fun defineViews(views: ViewSet) {
       views.createSystemContextView(system, "cla-context", null).apply {
         addDefaultElements()
-        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+        enableAutomaticLayout(AutomaticLayout.RankDirection.LeftRight, 300, 300)
       }
 
       views.createContainerView(system, "cla-container", null).apply {

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -11,6 +11,8 @@ class LegalAidAgencyUsers private constructor() {
     lateinit var provider: Person
     lateinit var crimeApplicationCaseWorker: Person
     lateinit var billingCaseWorker: Person
+    lateinit var directServicesTeam: Person
+    lateinit var contactCentreOperator: Person
 
     override fun defineModelEntities(model: Model) {
       citizen = model.addPerson(Location.External, "A member of the public in England and Wales", null)
@@ -21,10 +23,23 @@ class LegalAidAgencyUsers private constructor() {
         "Legal aid crime application case worker",
         "Manages applications for criminal legal aid"
       )
+
       billingCaseWorker = model.addPerson(
         Location.Internal,
         "Legal aid billing case workers",
         "Verifies legal aid provider's bills"
+      )
+
+      directServicesTeam = model.addPerson(
+        Location.Internal,
+        "Direct Services Team",
+        "Maintains the Civil Legal Aid operator relationship and performance"
+      )
+
+      contactCentreOperator = model.addPerson(
+        Location.Internal,
+        "Contact Centre Operator",
+        "Contact centre personell who signposts members of the public in their legal help queries"
       )
     }
 

--- a/src/main/kotlin/model/SendGrid.kt
+++ b/src/main/kotlin/model/SendGrid.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class SendGrid private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem("SendGrid", "Service for sending transactional email").apply {
+        OutsideLAA.addTo(this)
+      }
+    }
+
+    override fun defineInternalContainerRelationships() {
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineExternalRelationships() {
+    }
+
+    override fun defineUserRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+  }
+}

--- a/src/main/kotlin/model/TAD.kt
+++ b/src/main/kotlin/model/TAD.kt
@@ -1,0 +1,64 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Container
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.ViewSet
+
+class TAD private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+    lateinit var tad: Container
+    lateinit var db: Container
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Tender Assessment Database",
+        "A system for managing tender assessments"
+      )
+
+      tad = system.addContainer(
+        "Tender Asssessment Database",
+        "Web application for managing tender assessments, replaced by the Tender Verification (TV) system",
+        "Oracle Application Express (APEX)"
+      ).apply {
+        setUrl("https://github.com/ministryofjustice/laa-apex")
+        Tags.WEB_BROWSER.addTo(this)
+      }
+
+      db = system.addContainer(
+        "TAD Database",
+        "The TAD schema stores data for all of the Oracle APEX applications at the LAA",
+        "Oracle"
+      ).apply {
+        Tags.DATABASE.addTo(this)
+      }
+    }
+
+    override fun defineInternalContainerRelationships() {
+      tad.uses(db, "Connects to")
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineExternalRelationships() {
+    }
+
+    override fun defineUserRelationships() {
+    }
+
+    override fun defineViews(views: ViewSet) {
+      views.createSystemContextView(system, "tad-context", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.LeftRight, 300, 300)
+      }
+
+      views.createContainerView(system, "tad-container", null).apply {
+        addDefaultElements()
+        enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 300, 300)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

This pull request populates the CLA diagram with all of its components, persons, and connections. It also adds SendGrid and TAD which are used by CLA.

## What is the intent behind these changes?

To ensure all the known elements of CLA are fully documented. This does not include the systems it talks to, like TAD and SendGrid, which have more to them than is represented here.

## Previews
![structurizr-55246-cla-context](https://user-images.githubusercontent.com/1471406/100244188-903f4a00-2f2e-11eb-807f-ef3cac180ebb.png)

![structurizr-55246-cla-container](https://user-images.githubusercontent.com/1471406/100244207-9503fe00-2f2e-11eb-959e-0109e1f213d9.png)
