### PR TITLE
Add CCMS caseworker users

### DIFF
--- a/src/main/kotlin/model/CCMS.kt
+++ b/src/main/kotlin/model/CCMS.kt
@@ -12,6 +12,7 @@ class CCMS private constructor() {
     lateinit var providerDetailsAPI: Container
     lateinit var soa: Container
     lateinit var ebsDb: Container
+    lateinit var oracleForms: Container
     lateinit var providerUserInterface: Container
     lateinit var temporaryDataStore: Container
     lateinit var trainingWebsite: Container
@@ -58,6 +59,12 @@ class CCMS private constructor() {
         Tags.DATABASE.addTo(this)
       }
 
+      oracleForms = system.addContainer(
+        "CCMS Oracle Forms",
+        "Forms that provide a UI for interacting with the EBS database",
+        "Oracle"
+      )
+
       trainingWebsite = system.addContainer(
         "CCMS training",
         "A website with training, guidance and support for external users of CCMS",
@@ -73,6 +80,8 @@ class CCMS private constructor() {
 
       providerUserInterface.uses(temporaryDataStore, "Reads and writes data to")
       providerUserInterface.uses(soa, "Reads and writes applications to", "SOAP")
+
+      oracleForms.uses(ebsDb, "Reads and writes data to")
 
       temporaryDataStore.uses(ebsDb, "Reads data from", "Shared database")
     }
@@ -94,6 +103,9 @@ class CCMS private constructor() {
     override fun defineUserRelationships() {
       LegalAidAgencyUsers.provider.uses(trainingWebsite, "Learns how to use CCMS")
       LegalAidAgencyUsers.provider.uses(providerUserInterface, "Completes applications")
+      LegalAidAgencyUsers.meansCaseWorker.uses(oracleForms, "Assesses legal aid applications for means eligibility")
+      LegalAidAgencyUsers.meritsCaseWorker.uses(oracleForms, "Assesses legal aid applications for merits eligibility")
+      LegalAidAgencyUsers.billingCaseWorker.uses(oracleForms, "Verifies provider bills")
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -11,6 +11,8 @@ class LegalAidAgencyUsers private constructor() {
     lateinit var provider: Person
     lateinit var crimeApplicationCaseWorker: Person
     lateinit var billingCaseWorker: Person
+    lateinit var meansCaseWorker: Person
+    lateinit var meritsCaseWorker: Person
     lateinit var directServicesTeam: Person
     lateinit var contactCentreOperator: Person
 
@@ -18,15 +20,18 @@ class LegalAidAgencyUsers private constructor() {
       citizen = model.addPerson(Location.External, "A member of the public in England and Wales", null)
       provider = model.addPerson(Location.External, "Legal Aid Provider", null)
 
+      meansCaseWorker = model.addPerson(Location.Internal, "Legal Aid means case worker", null)
+      meritsCaseWorker = model.addPerson(Location.Internal, "Legal Aid merits case worker", null)
+
       crimeApplicationCaseWorker = model.addPerson(
         Location.Internal,
-        "Legal aid crime application case worker",
+        "Legal Aid crime application case worker",
         "Manages applications for criminal legal aid"
       )
 
       billingCaseWorker = model.addPerson(
         Location.Internal,
-        "Legal aid billing case workers",
+        "Legal Aid billing case worker",
         "Verifies legal aid provider's bills"
       )
 

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -20,19 +20,28 @@ class LegalAidAgencyUsers private constructor() {
       citizen = model.addPerson(Location.External, "A member of the public in England and Wales", null)
       provider = model.addPerson(Location.External, "Legal Aid Provider", null)
 
-      meansCaseWorker = model.addPerson(Location.Internal, "Legal Aid means case worker", null)
-      meritsCaseWorker = model.addPerson(Location.Internal, "Legal Aid merits case worker", null)
-
       crimeApplicationCaseWorker = model.addPerson(
         Location.Internal,
-        "Legal Aid crime application case worker",
-        "Manages applications for criminal legal aid"
+        "Crime application caseworker",
+        "A caseworker who manages applications for criminal legal aid"
       )
 
       billingCaseWorker = model.addPerson(
         Location.Internal,
-        "Legal Aid billing case worker",
-        "Verifies legal aid provider's bills"
+        "Billing caseworker",
+        "A caseworker who verifies legal aid provider's bills"
+      )
+
+      meansCaseWorker = model.addPerson(
+        Location.Internal,
+        "Means caseworker",
+        "A caseworker who assesses legal aid applications for means"
+      )
+
+      meritsCaseWorker = model.addPerson(
+        Location.Internal,
+        "Merits caseworker",
+        "A caseworker who assesses legal aid applications for merits"
       )
 
       directServicesTeam = model.addPerson(
@@ -44,7 +53,7 @@ class LegalAidAgencyUsers private constructor() {
       contactCentreOperator = model.addPerson(
         Location.Internal,
         "Contact Centre Operator",
-        "Contact centre personell who signposts members of the public in their legal help queries"
+        "Contact centre personel who signposts members of the public in their legal help queries"
       )
     }
 


### PR DESCRIPTION
## What does this pull request do?

Closes #28 
Addresses part of #56. 

- I've only added Oracle Forms as that seemed the necessary component for representing the CCMS caseworker interaction. I was thinking that the other components of issue 56 could be added as a separate PR.

- I've described the caseworker role in the interaction with Oracle Forms rather than on the person definition in LegalAidAgencyUsers. This is purely because it looks nicer that way! Happy to change. 

- I'm also not entirely clear on the role of the billing case worker here.

## What is the intent behind these changes?

Represent caseworkers on the CCMS container diagram:
![structurizr-55246-ccms-context-container](https://user-images.githubusercontent.com/17312421/100859378-11df2c80-3487-11eb-8ef3-d054046e60f0.png)

