### PR TITLE
Add crime filtered view

### DIFF
--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.architecture
 import com.structurizr.model.Element
 
 enum class Tags : addTo {
+  CRIME,
   DATABASE,
   WEB_BROWSER,
   PROVIDER {

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -17,3 +17,10 @@ enum class Tags : addTo {
     element.addTags(this.toString())
   }
 }
+
+fun tagsToArgument(vararg tags: Tags):Array<String> {
+  val stringedTags =  arrayListOf<String>()
+  tags.forEach { stringedTags.add(it.toString()) }
+
+  return stringedTags.toTypedArray()
+}

--- a/src/main/kotlin/defineFilteredViews.kt
+++ b/src/main/kotlin/defineFilteredViews.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.view.AutomaticLayout
+import com.structurizr.view.FilterMode
+import com.structurizr.view.ViewSet
+
+fun defineFilteredViews(tags: List<Tags>, views: ViewSet) {
+  val systemLandscapeView = views.createSystemLandscapeView("System Landscape", "All systems + people").apply {
+    addAllElements()
+  }
+
+  tags.forEach {
+    views.createFilteredView(
+      systemLandscapeView,
+      it.toString().toLowerCase(),
+      "All applications filtered by " + it.toString().toLowerCase(),
+      FilterMode.Include,
+      it.toString()
+    ).apply {
+      view.enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 400, 400, 100, false)
+    }
+  }
+}

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -41,6 +41,10 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   InfoX
 )
 
+private val TAGS_FOR_FILTER_VIEWS = listOf<Tags>(
+  Tags.CRIME
+)
+
 private fun defineModelItems(model: Model) {
   model.setImpliedRelationshipsStrategy(
     CreateImpliedRelationshipsUnlessAnyRelationshipExistsStrategy()
@@ -86,6 +90,7 @@ fun defineWorkspace(): Workspace {
   defineViews(workspace.views)
   defineStyles(workspace.views.configuration.styles)
   defineDocumentation(workspace)
+  defineFilteredViews(TAGS_FOR_FILTER_VIEWS, workspace.views)
 
   return workspace
 }

--- a/src/main/kotlin/model/CCLF.kt
+++ b/src/main/kotlin/model/CCLF.kt
@@ -16,7 +16,9 @@ class CCLF private constructor() {
       system = model.addSoftwareSystem(
         "Crown Court Litigator Fees",
         "The CCLF system is a web service that manages litigators fee claims."
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       web = system.addContainer(
         "Crown Court Litigator Fees UI",
@@ -41,8 +43,10 @@ class CCLF private constructor() {
     }
 
     override fun defineRelationships() {
-      web.uses(CCCD.system, "Gets Claims information from and sends claim decision")
-      
+      web.uses(
+        CCCD.system, "Gets Claims information from and sends claim decision", null, null, tagsToArgument(Tags.CRIME)
+      )
+
       web.uses(CCCD.sqsCCLF, "Processes job to know to pull claim information")
       web.uses(CCCD.sqsProcessResponse, "Notifies CCCD of success/failure of claim")
       web.uses(CCCD.web, "Pulls claims from", "HTTP API")
@@ -52,7 +56,9 @@ class CCLF private constructor() {
     }
 
     override fun defineUserRelationships() {
-      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Processes claim accessments for Litigators fees (LGFS)")
+      LegalAidAgencyUsers.billingCaseWorker.uses(
+        web, "Processes claim accessments for Litigators fees (LGFS)", null, null, tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/CCR.kt
+++ b/src/main/kotlin/model/CCR.kt
@@ -16,7 +16,9 @@ class CCR private constructor() {
       system = model.addSoftwareSystem(
         "Crown Court Remuneration",
         "The CCR system is a web service that Manages Advocate fee claims."
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       web = system.addContainer(
         "Crown Court Remuneration UI",
@@ -41,18 +43,44 @@ class CCR private constructor() {
     }
 
     override fun defineRelationships() {
-      web.uses(CCCD.system, "Gets Claims information from and sends claim decision")
+      web.uses(
+        CCCD.system,
+        "Gets Claims information from and sends claim decision",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
 
-      web.uses(CCCD.sqsCCR, "Processes job to know to pull claim information")
-      web.uses(CCCD.sqsProcessResponse, "Notifies CCCD of success/failure of claim")
-      web.uses(CCCD.web, "Pulls claims from", "HTTP API")
+      web.uses(
+        CCCD.sqsCCR,
+        "Processes job to know to pull claim information",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
+      web.uses(
+        CCCD.sqsProcessResponse,
+        "Notifies CCCD of success/failure of claim",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
+      web.uses(
+        CCCD.web,
+        "Pulls claims from",
+        "HTTP API",
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {
     }
 
     override fun defineUserRelationships() {
-      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Processes claim accessments for Advocate fees (AGFS)")
+      LegalAidAgencyUsers.billingCaseWorker.uses(
+        web, "Processes claim accessments for Advocate fees (AGFS)", null, null, tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineViews(views: ViewSet) {

--- a/src/main/kotlin/model/CDA.kt
+++ b/src/main/kotlin/model/CDA.kt
@@ -20,7 +20,9 @@ class CDA private constructor() {
         "Court Data Adapter",
         "The laa-court-data-adaptor system is a web service that connects to LAA systems and " +
           "to HMCTS Common Platform (CP)"
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       api = system.addContainer(
         "Court Data Adapter API",
@@ -69,7 +71,9 @@ class CDA private constructor() {
       api.uses(
         MAAT.api,
         "Uses MAAT API to validate MAAT IDs before sending requests to Common Platform",
-        "REST"
+        "REST",
+        null,
+        tagsToArgument(Tags.CRIME)
       )
     }
 
@@ -77,7 +81,9 @@ class CDA private constructor() {
       api.uses(
         CommonPlatform.system,
         "Uses APIs to search & retreive case information, marks cases to receive notifications\n",
-        "REST (w/ mTLS)"
+        "REST (w/ mTLS)",
+        null,
+        tagsToArgument(Tags.CRIME)
       )
     }
 

--- a/src/main/kotlin/model/CommonPlatform.kt
+++ b/src/main/kotlin/model/CommonPlatform.kt
@@ -14,6 +14,7 @@ class CommonPlatform private constructor() {
         "Contains information about Court Cases in Magistrates and Crown Courts"
       ).apply {
         OutsideLAA.addTo(this)
+        Tags.CRIME.addTo(this)
       }
     }
 
@@ -21,7 +22,13 @@ class CommonPlatform private constructor() {
     }
 
     override fun defineRelationships() {
-      system.uses(CDA.api, "Provides notifications when Hearings have resulted", "REST (w/ mTLS)")
+      system.uses(
+        CDA.api,
+        "Provides notifications when Hearings have resulted",
+        "REST (w/ mTLS)",
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {

--- a/src/main/kotlin/model/InfoX.kt
+++ b/src/main/kotlin/model/InfoX.kt
@@ -15,7 +15,9 @@ class InfoX private constructor() {
       system = model.addSoftwareSystem(
         "InfoX",
         "Adapter for LAA to HMCTS's Libra"
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       app = system.addContainer(
         "InfoX",
@@ -31,8 +33,12 @@ class InfoX private constructor() {
     }
 
     override fun defineRelationships() {
-      app.uses(Libra.system, "Sends representation orders status", "SOAP")
-      app.uses(MAAT.db, "Writes notifications to")
+      app.uses(
+        Libra.system, "Sends representation orders status", "SOAP", null, tagsToArgument(Tags.CRIME)
+      )
+      app.uses(
+        MAAT.db, "Writes notifications to", null, null, tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {

--- a/src/main/kotlin/model/LegalAidAgencyUsers.kt
+++ b/src/main/kotlin/model/LegalAidAgencyUsers.kt
@@ -25,6 +25,7 @@ class LegalAidAgencyUsers private constructor() {
         "Crime application caseworker",
         "A caseworker who manages applications for criminal legal aid"
       )
+      crimeApplicationCaseWorker.addTags(Tags.CRIME.toString())
 
       billingCaseWorker = model.addPerson(
         Location.Internal,
@@ -43,6 +44,7 @@ class LegalAidAgencyUsers private constructor() {
         "Merits caseworker",
         "A caseworker who assesses legal aid applications for merits"
       )
+      billingCaseWorker.addTags(Tags.CRIME.toString())
 
       directServicesTeam = model.addPerson(
         Location.Internal,

--- a/src/main/kotlin/model/Libra.kt
+++ b/src/main/kotlin/model/Libra.kt
@@ -14,6 +14,7 @@ class Libra private constructor() {
         "Legacy application that contains information about Court Cases in Magistrates Courts"
       ).apply {
         OutsideLAA.addTo(this)
+        Tags.CRIME.addTo(this)
       }
     }
 
@@ -21,7 +22,13 @@ class Libra private constructor() {
     }
 
     override fun defineRelationships() {
-      system.uses(InfoX.app, "Provides notifications when Hearings have resulted", "SOAP")
+      system.uses(
+        InfoX.app,
+        "Provides notifications when Hearings have resulted",
+        "SOAP",
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {

--- a/src/main/kotlin/model/MAAT.kt
+++ b/src/main/kotlin/model/MAAT.kt
@@ -16,7 +16,9 @@ class MAAT private constructor() {
       system = model.addSoftwareSystem(
         "Means Assessment & Administration Tool",
         "The MAAT system is a collection of applications are used in the application process for Criminal Legal Aid"
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       api = system.addContainer(
         "MAAT API",
@@ -42,9 +44,27 @@ class MAAT private constructor() {
     }
 
     override fun defineRelationships() {
-      api.uses(CDA.system, "Sends status updates to and process events from")
-      api.uses(CDA.api, "Posts offence level status events", "REST")
-      api.uses(CDA.sqsQueue, "Processes notifications from the queue", "SQS")
+      api.uses(
+        CDA.system,
+        "Sends status updates to and process events from",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
+      api.uses(
+        CDA.api,
+        "Posts offence level status events",
+        "REST",
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
+      api.uses(
+        CDA.sqsQueue,
+        "Processes notifications from the queue",
+        "SQS",
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {

--- a/src/main/kotlin/model/MLRA.kt
+++ b/src/main/kotlin/model/MLRA.kt
@@ -15,7 +15,9 @@ class MLRA private constructor() {
       system = model.addSoftwareSystem(
         "MAAT Libra Interface Application",
         "The MLRA system provides an interface between MAAT and HMCTS's LIBRA application for Caseworkers"
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       web = system.addContainer(
         "MLRA UI",
@@ -32,8 +34,20 @@ class MLRA private constructor() {
     }
 
     override fun defineRelationships() {
-      web.uses(MAAT.db, "Uses as its own Database")
-      web.uses(InfoX.app, "Searches cases and sends representation order status")
+      web.uses(
+        MAAT.db,
+        "Uses as its own Database",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
+      web.uses(
+        InfoX.app,
+        "Searches cases and sends representation order status",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {

--- a/src/main/kotlin/model/NOLASA.kt
+++ b/src/main/kotlin/model/NOLASA.kt
@@ -16,7 +16,9 @@ class NOLASA private constructor() {
         "Not On Libra Auto-Search Application",
         "Is a micro-service that reads cases that have been marked as 'not-on-libra' from the MLRA " +
           "database once a day and auto-searches the HMCTS Libra system"
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       app = system.addContainer(
         "NOLASA",
@@ -32,8 +34,20 @@ class NOLASA private constructor() {
     }
 
     override fun defineRelationships() {
-      app.uses(MAAT.db, "Uses as its own Database")
-      app.uses(InfoX.app, "Searches for cases")
+      app.uses(
+        MAAT.db,
+        "Uses as its own Database",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
+      app.uses(
+        InfoX.app,
+        "Searches for cases",
+        null,
+        null,
+        tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineExternalRelationships() {

--- a/src/main/kotlin/model/VCD.kt
+++ b/src/main/kotlin/model/VCD.kt
@@ -19,7 +19,9 @@ class VCD private constructor() {
         "View Court Data",
         "The laa-court-data-ui system is a web service that Application and Billing case workers use to interact " +
           "with the Courts"
-      )
+      ).apply {
+        Tags.CRIME.addTo(this)
+      }
 
       web = system.addContainer(
         "View Court Data UI",
@@ -58,7 +60,9 @@ class VCD private constructor() {
       web.uses(
         CDA.api,
         "Provides interface to HMCTS Common Platform to access Court case and hearing information",
-        "REST"
+        "REST",
+        null,
+        tagsToArgument(Tags.CRIME)
       )
     }
 
@@ -66,8 +70,12 @@ class VCD private constructor() {
     }
 
     override fun defineUserRelationships() {
-      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(web, "Searches and links/unlinks defendants to MAAT")
-      LegalAidAgencyUsers.billingCaseWorker.uses(web, "Searches and inspects defendants' case hearing history")
+      LegalAidAgencyUsers.crimeApplicationCaseWorker.uses(
+        web, "Searches and links/unlinks defendants to MAAT", null, null, tagsToArgument(Tags.CRIME)
+      )
+      LegalAidAgencyUsers.billingCaseWorker.uses(
+        web, "Searches and inspects defendants' case hearing history", null, null, tagsToArgument(Tags.CRIME)
+      )
     }
 
     override fun defineViews(views: ViewSet) {


### PR DESCRIPTION
## What does this pull request do?

Creates System Landscape diagram with only Systems, Users + Relationships tagged with Crime

## What is the intent behind these changes?

I want to show a diagram with all the systems and users only related to Crime. This can be the basis for creating any diagram based off Tags.

## Notes

This diagram is only generated on Structurizr. Not locally and using PlantUML

## Diagram

![structurizr-61040-crime (1)](https://user-images.githubusercontent.com/1273965/101018337-46c0b180-3563-11eb-908d-2517911b6bf8.png)
