### PR TITLE
Add relationship between CWA and MAAT

### DIFF
--- a/src/main/kotlin/model/CWA.kt
+++ b/src/main/kotlin/model/CWA.kt
@@ -52,6 +52,8 @@ class CWA private constructor() {
         "HUB",
         InteractionStyle.Asynchronous
       )
+
+      db.uses(MAAT.db, "Pushes provider names and office addresses to", "HUB")
     }
 
     override fun defineUserRelationships() {


### PR DESCRIPTION
HUB pulls data out of CWA via job SMS02 and pushes it into MAAT via
MAAT1.

## What does this pull request do?

Documents the relationship between CWA and MAAT.

## What is the intent behind these changes?

To document more of the relationships between CWA and other systems.

![structurizr-55246-cwa-container](https://user-images.githubusercontent.com/1471406/101376199-303e9100-38a8-11eb-9511-ffd66c843bd3.png)

