### PR TITLE
Update naming of filtered views

### DIFF
--- a/src/main/kotlin/defineFilteredViews.kt
+++ b/src/main/kotlin/defineFilteredViews.kt
@@ -5,17 +5,19 @@ import com.structurizr.view.FilterMode
 import com.structurizr.view.ViewSet
 
 fun defineFilteredViews(tags: List<Tags>, views: ViewSet) {
-  val systemLandscapeView = views.createSystemLandscapeView("System Landscape", "All systems + people").apply {
-    addAllElements()
-  }
 
   tags.forEach {
+    val name = it.toString()
+    val landscapeView = views.createSystemLandscapeView("x-" + name.toLowerCase(), "Elements by $name").apply {
+      addAllElements()
+    }
+
     views.createFilteredView(
-      systemLandscapeView,
-      it.toString().toLowerCase(),
-      "All applications filtered by " + it.toString().toLowerCase(),
+      landscapeView,
+      name,
+      "$name applications",
       FilterMode.Include,
-      it.toString()
+      name
     ).apply {
       view.enableAutomaticLayout(AutomaticLayout.RankDirection.TopBottom, 400, 400, 100, false)
     }

--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -77,6 +77,7 @@ private fun defineRelationships() {
 
 private fun defineViews(views: ViewSet) {
   MODEL_ITEMS.forEach { it.defineViews(views) }
+  defineFilteredViews(TAGS_FOR_FILTER_VIEWS, views)
   defineGlobalViews(views)
 }
 
@@ -93,7 +94,6 @@ fun defineWorkspace(): Workspace {
   defineViews(workspace.views)
   defineStyles(workspace.views.configuration.styles)
   defineDocumentation(workspace)
-  defineFilteredViews(TAGS_FOR_FILTER_VIEWS, workspace.views)
 
   return workspace
 }


### PR DESCRIPTION
## What does this pull request do?

- Names the views with the tag used to filter.
- Adds a prefix to ensure these views appear beneath the main landscape view in Structurizr.

## What is the intent behind these changes?

Closes #68 

If this is approved, I have a follow up PR to add views for the LAA concepts of _get access, get LA, get paid_.

