### PR TITLE
Need to move HUB order to improve CRIME landscape view

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -25,6 +25,7 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   VCD,
   CommonPlatform,
   CDA,
+  HUB,
   OSPlacesAPI,
   MAAT,
   BankHolidaysAPI,
@@ -50,7 +51,6 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   Xhibit,
   FeeCalculator,
   ProviderCMS,
-  HUB,
   DWP
 )
 


### PR DESCRIPTION
## What does this pull request do?

Moving HUB helps improve the visual on the CRIME landscape diagram. CCR was covered by a label of a relationship.

![image (14)](https://user-images.githubusercontent.com/1273965/103888134-1af19800-50dc-11eb-82f3-7ee16a652ebd.png)


## What is the intent behind these changes?

To improve the layout

## Diagram

![structurizr-61040-CRIME (4)](https://user-images.githubusercontent.com/1273965/103888155-23e26980-50dc-11eb-91f5-bea550192ec7.png)
