### PR TITLE
Move Provider Training website into its own Software System

### DIFF
--- a/src/main/kotlin/defineWorkspace.kt
+++ b/src/main/kotlin/defineWorkspace.kt
@@ -51,7 +51,8 @@ private val MODEL_ITEMS = listOf<LAASoftwareSystem>(
   Xhibit,
   FeeCalculator,
   ProviderCMS,
-  DWP
+  DWP,
+  ProviderTraining
 )
 
 private val TAGS_FOR_FILTER_VIEWS = listOf<Tags>(

--- a/src/main/kotlin/model/CCMS.kt
+++ b/src/main/kotlin/model/CCMS.kt
@@ -16,7 +16,6 @@ class CCMS private constructor() {
     lateinit var oracleForms: Container
     lateinit var providerUserInterface: Container
     lateinit var temporaryDataStore: Container
-    lateinit var trainingWebsite: Container
     lateinit var opaWebDeterminations: Container
     lateinit var connector: Container
 
@@ -71,14 +70,6 @@ class CCMS private constructor() {
         "Forms that provide a UI for interacting with the EBS database",
         "Oracle"
       )
-
-      trainingWebsite = system.addContainer(
-        "CCMS training",
-        "A website with training, guidance and support for external users of CCMS",
-        "Squiz Matrix"
-      ).apply {
-        url = "https://ccmstraining.justice.gov.uk/"
-      }
 
       opaWebDeterminations = system.addContainer(
         "Oracle Web Determinations",
@@ -157,7 +148,6 @@ class CCMS private constructor() {
         "Makes legal aid application on behalf of"
       )
 
-      LegalAidAgencyUsers.provider.uses(trainingWebsite, "Learns how to use CCMS")
       LegalAidAgencyUsers.provider.uses(providerUserInterface, "Completes applications")
       LegalAidAgencyUsers.meansCaseWorker.uses(oracleForms, "Assesses legal aid applications for means eligibility")
       LegalAidAgencyUsers.meritsCaseWorker.uses(oracleForms, "Assesses legal aid applications for merits eligibility")

--- a/src/main/kotlin/model/ProviderTraining.kt
+++ b/src/main/kotlin/model/ProviderTraining.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.laa.architecture
+
+import com.structurizr.model.Model
+import com.structurizr.model.SoftwareSystem
+import com.structurizr.view.ViewSet
+
+class ProviderTraining private constructor() {
+  companion object : LAASoftwareSystem {
+    lateinit var system: SoftwareSystem
+
+    override fun defineModelEntities(model: Model) {
+      system = model.addSoftwareSystem(
+        "Provider training",
+        "A website with training, guidance and support for providers"
+      ).apply {
+        url = "https://legalaidlearning.justice.gov.uk/"
+      }
+    }
+
+    override fun defineInternalContainerRelationships() {
+    }
+
+    override fun defineExternalRelationships() {
+    }
+
+    override fun defineRelationships() {
+    }
+
+    override fun defineUserRelationships() {
+      LegalAidAgencyUsers.provider.uses(system, "Learns how to use CCMS")
+    }
+
+    override fun defineViews(views: ViewSet) {
+    }
+
+  }
+}


### PR DESCRIPTION
## What does this pull request do?

Move Provider Training website into its own Software System

## What is the intent behind these changes?

As of 1st November 2020, the CCMS Training website has been
replaced with a more generic learning platform.

Announcement:
```
A new website is being launched on 1 November 2020 to replace the existing Client and Cost Management System (CCMS) training website. Resources will be gradually transferred to the new website. User improvements include:

...

Long-term, the aim will be for the new training and support website to host crime as well as civil training information. A redirect will automatically take you to the new home page from 1 November if you click on the old CCMS training URL.
```

Closes #43

## Images

System Landscape Diagram:
![structurizr-55246-system-overview](https://user-images.githubusercontent.com/976274/104335601-6e545380-54eb-11eb-8b77-96daa92414a9.png)
